### PR TITLE
Add LINK and ETH to Bridge Address

### DIFF
--- a/config/src/projects/optimism.ts
+++ b/config/src/projects/optimism.ts
@@ -29,7 +29,7 @@ export const optimism: Project = {
     {
       address: '0x99C9fc46f92E8a1c0deC1b1747d010903E884bE1',
       sinceBlock: 12686786,
-      tokens: ['USDT', 'WBTC', 'LINK', 'ETH'],
+      tokens: ['ETH', 'LINK', 'USDT', 'WBTC'],
     },
   ],
   details: {

--- a/config/src/projects/optimism.ts
+++ b/config/src/projects/optimism.ts
@@ -29,7 +29,7 @@ export const optimism: Project = {
     {
       address: '0x99C9fc46f92E8a1c0deC1b1747d010903E884bE1',
       sinceBlock: 12686786,
-      tokens: ['USDT', 'WBTC'],
+      tokens: ['USDT', 'WBTC', 'LINK', 'ETH'],
     },
   ],
   details: {


### PR DESCRIPTION
The L1 Bridge Contract 0x99C9fc46f92E8a1c0deC1b1747d010903E884bE1 also holds deposits of ETH and LINK. I also suspect that it is the bridge for EURT but have not yet confirmed this to be true.